### PR TITLE
DualSense gyro support.

### DIFF
--- a/Config/Input.ini
+++ b/Config/Input.ini
@@ -1,2 +1,2 @@
 [InputPlatformSettings_Windows InputPlatformSettings]
-+HardwareDevices=(InputClassName="DsInputDevice",HardwareDeviceIdentifier="DualSense",PrimaryDeviceType=Gamepad,SupportedFeaturesMask=462)
++HardwareDevices=(InputClassName="DsInputDevice",HardwareDeviceIdentifier="DualSense",PrimaryDeviceType=Gamepad,SupportedFeaturesMask=8654)

--- a/Source/FabulousDualSense/Private/DsConstants.cpp
+++ b/Source/FabulousDualSense/Private/DsConstants.cpp
@@ -19,6 +19,11 @@ const FKey DsConstants::Touch2AxisXKey{FName{TEXTVIEW("DsTouch2AxisX")}};
 const FKey DsConstants::Touch2AxisYKey{FName{TEXTVIEW("DsTouch2AxisY")}};
 const FKey DsConstants::Touch2AxisXYKey{FName{TEXTVIEW("DsTouch2AxisXY")}};
 
+const FKey DsConstants::GyroscopeAxisRollKey{ FName{TEXTVIEW("DsGyroscopeRoll")}};
+const FKey DsConstants::GyroscopeAxisPitchKey{ FName{TEXTVIEW("DsGyroscopePitch")}};
+const FKey DsConstants::GyroscopeAxisYawKey{ FName{TEXTVIEW("DsGyroscopeYaw")}};
+const FKey DsConstants::GyroscopeAxisYawPitchKey{ FName{TEXTVIEW("DsGyroscopeYawPitch")}};
+
 const TMap<FGamepadKeyNames::Type, uint32>& DsConstants::GetRegularButtons()
 {
 	static const TMap<FGamepadKeyNames::Type, uint32> Buttons{

--- a/Source/FabulousDualSense/Private/DsInputDevice.cpp
+++ b/Source/FabulousDualSense/Private/DsInputDevice.cpp
@@ -95,6 +95,29 @@ void FDsInputDevice::SendControllerEvents()
 			                                   Input.rightTrigger / static_cast<float>(TNumericLimits<uint8>::Max()));
 		}
 
+		// Gyroscope.
+
+		// Gyroscope X represents Unreal Engine's pitch axis
+		if (PreviousInput.gyroscope.x != Input.gyroscope.x)
+		{
+			MessageHandler->OnControllerAnalog(DsConstants::GyroscopeAxisPitchKey.GetFName(), PlatformUserId, InputDeviceId,
+				Input.gyroscope.x * 0.0001);
+		}
+
+		// Gyroscope Y represents Unreal Engine's yaw axis
+		if (PreviousInput.gyroscope.y != Input.gyroscope.y)
+		{
+			MessageHandler->OnControllerAnalog(DsConstants::GyroscopeAxisYawKey.GetFName(), PlatformUserId, InputDeviceId,
+				Input.gyroscope.y * 0.0001);
+		}
+
+		// Gyroscope Z represents Unreal Engine's roll axis
+		if (PreviousInput.gyroscope.z != Input.gyroscope.z)
+		{
+			MessageHandler->OnControllerAnalog(DsConstants::GyroscopeAxisRollKey.GetFName(), PlatformUserId, InputDeviceId,
+				Input.gyroscope.z * 0.0001);
+		}
+
 		// Regular buttons.
 
 		auto ButtonIndex{0};

--- a/Source/FabulousDualSense/Private/FabulousDualSenseModule.cpp
+++ b/Source/FabulousDualSense/Private/FabulousDualSenseModule.cpp
@@ -61,6 +61,28 @@ void FFabulousDualSenseModule::StartupModule()
 		                    FKeyDetails::GamepadKey | FKeyDetails::Touch | FKeyDetails::Axis2D | FKeyDetails::UpdateAxisWithoutSamples,
 		                    CategoryName
 	                    }, DsConstants::Touch2AxisXKey, DsConstants::Touch2AxisYKey);
+	
+	// Gyroscope.
+	
+	EKeys::AddKey({
+		DsConstants::GyroscopeAxisRollKey, LOCTEXT("GyroscopeAxisRollKey", "DualSense Gyroscope Roll Axis"),
+		FKeyDetails::GamepadKey | FKeyDetails::Axis1D | FKeyDetails::UpdateAxisWithoutSamples, CategoryName
+	});
+	
+	EKeys::AddKey({
+		DsConstants::GyroscopeAxisPitchKey, LOCTEXT("GyroscopeAxisPitchKey", "DualSense Gyroscope Pitch Axis"),
+		FKeyDetails::GamepadKey | FKeyDetails::Axis1D | FKeyDetails::UpdateAxisWithoutSamples, CategoryName
+	});
+	
+	EKeys::AddKey({
+		DsConstants::GyroscopeAxisYawKey, LOCTEXT("GyroscopeAxisYawKey", "DualSense Gyroscope Yaw Axis"),
+		FKeyDetails::GamepadKey | FKeyDetails::Axis1D | FKeyDetails::UpdateAxisWithoutSamples, CategoryName
+	});
+	
+	EKeys::AddPairedKey({
+		DsConstants::GyroscopeAxisYawPitchKey, LOCTEXT("GyroscopeAxisYawPitchKey", "DualSense Gyroscope Yaw/Pitch Axis"),
+		FKeyDetails::GamepadKey | FKeyDetails::Axis2D | FKeyDetails::UpdateAxisWithoutSamples, CategoryName
+	}, DsConstants::GyroscopeAxisYawKey, DsConstants::GyroscopeAxisPitchKey);
 }
 
 TSharedPtr<IInputDevice> FFabulousDualSenseModule::CreateInputDevice(const TSharedRef<FGenericApplicationMessageHandler>& MessageHandler)

--- a/Source/FabulousDualSense/Public/DsConstants.h
+++ b/Source/FabulousDualSense/Public/DsConstants.h
@@ -27,5 +27,10 @@ namespace DsConstants
 	FABULOUSDUALSENSE_API extern const FKey Touch2AxisYKey;
 	FABULOUSDUALSENSE_API extern const FKey Touch2AxisXYKey;
 
+	FABULOUSDUALSENSE_API extern const FKey GyroscopeAxisRollKey;
+	FABULOUSDUALSENSE_API extern const FKey GyroscopeAxisPitchKey;
+	FABULOUSDUALSENSE_API extern const FKey GyroscopeAxisYawKey;
+	FABULOUSDUALSENSE_API extern const FKey GyroscopeAxisYawPitchKey;
+
 	FABULOUSDUALSENSE_API const TMap<FGamepadKeyNames::Type, uint32>& GetRegularButtons();
 }


### PR DESCRIPTION
Added support for the DualSense gyroscope, including a combined Yaw/Pitch axis designed for easy gyro aiming.

The values provided by the hardware are way too large for any possible use case I can see, so the raw gyroscope values are multiplied by 0.0001. Precise aiming in a game will probably require even smaller values, but this can be done by setting a Scalar in an InputMappingContext using EnhancedInput. The values calculated by this code seem like a good middle ground between "way too small" and "too impossibly large to do anything with".